### PR TITLE
Fix build warnings and release error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,6 @@ jobs:
         if: ${{ matrix.musl }}
         with:
           java-version: '21'
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
           native-image-musl: 'true'
@@ -48,7 +47,6 @@ jobs:
         if: ${{ !matrix.musl }}
         with:
           java-version: '21'
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -8,7 +8,9 @@ project:
   license: Apache-2.0
   extraProperties:
     inceptionYear: 2023
-
+  java:
+    groupId: io.seqera.wave.cli
+    version: 21
 release:
   github:
     overwrite: true


### PR DESCRIPTION
This PR will fix build warnings and release error:
1. remove components: 'native-image', which is no more required in Java 21
2. Added Java version in jreleaser.yml required by fatjar 