### PR TITLE
change gc to g1gc for linux distribution of cli

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ graalvmNative {
             configurationFileDirectories.from(file('conf'))
 
             if (System.env.getOrDefault("PLATFORM", "") == "linux-x86_64") {
-                buildArgs(['--static', '--libc=musl'])
+                buildArgs(['--static', '--libc=musl', '--gc=G1'])
             }
 
             javaLauncher = javaToolchains.launcherFor {
@@ -86,7 +86,6 @@ graalvmNative {
             buildArgs.add('-R:MaxHeapSize=100M')
             buildArgs.add('-R:MinHeapSize=10M')
             buildArgs.add('-R:MaxNewSize=25M')
-            buildArgs.add('--gc=G1')
         }
     }
     toolchainDetection = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ graalvmNative {
             buildArgs.add('-R:MaxHeapSize=100M')
             buildArgs.add('-R:MinHeapSize=10M')
             buildArgs.add('-R:MaxNewSize=25M')
+            buildArgs.add('--gc=G1')
         }
     }
     toolchainDetection = true


### PR DESCRIPTION
This PR will solve the virtual memory issue of cli https://github.com/seqeralabs/wave-cli/issues/46

Native-image provided two solutions:
1. use g1gc
2. use `-H:-UseCompressedReferences`. This is only available in graalvm enterprise edition.


This PR will change the GC to G1 when the target machine is Linux.

Note: After enabling g1gc, the size of binary is increased by 11.6 MB.
```
munish.chouhan@Munishs-MacBook-Pro wave-cli-test % ls -ltr
-rw-r--r--@ 1 munish.chouhan  staff  61200224 Apr  5 13:47 wave
-rw-r--r--@ 1 munish.chouhan  staff  49582000 Apr  8 15:41 wave-1.2.0-linux-x86_64
```