### PR TITLE
Remove seqera from default Conda channels

### DIFF
--- a/app/src/main/java/io/seqera/wave/cli/App.java
+++ b/app/src/main/java/io/seqera/wave/cli/App.java
@@ -158,7 +158,7 @@ public class App implements Runnable {
     private List<String> condaRunCommands;
 
     @Option(names = {"--conda-channels"}, paramLabel = "''", description = "Conda channels used to build the container (default: ${DEFAULT-VALUE}).")
-    private String condaChannels = "seqera,conda-forge,bioconda,defaults";
+    private String condaChannels = "conda-forge,bioconda,defaults";
 
     @Option(names = {"--spack-file"}, paramLabel = "''",  description = "A Spack file used to build the container e.g. /some/path/spack.yaml.")
     private String spackFile;

--- a/app/src/test/groovy/io/seqera/wave/cli/AppCondaOptsTest.groovy
+++ b/app/src/test/groovy/io/seqera/wave/cli/AppCondaOptsTest.groovy
@@ -141,7 +141,7 @@ class AppCondaOptsTest extends Specification {
             '''.stripIndent(true)
         and:
         req.packages.condaOpts == new CondaOpts(mambaImage: CondaOpts.DEFAULT_MAMBA_IMAGE, basePackages: CondaOpts.DEFAULT_PACKAGES)
-        req.packages.channels == ['seqera', 'conda-forge', 'bioconda', 'defaults']
+        req.packages.channels == ['conda-forge', 'bioconda', 'defaults']
         and:
         !req.packages.entries
         and:
@@ -166,7 +166,7 @@ class AppCondaOptsTest extends Specification {
         req.packages.entries == ['foo']
         and:
         req.packages.condaOpts == new CondaOpts(mambaImage: CondaOpts.DEFAULT_MAMBA_IMAGE, basePackages: CondaOpts.DEFAULT_PACKAGES)
-        req.packages.channels == ['seqera', 'conda-forge', 'bioconda', 'defaults']
+        req.packages.channels == ['conda-forge', 'bioconda', 'defaults']
         and:
         !req.packages.environment
         and:
@@ -187,7 +187,7 @@ class AppCondaOptsTest extends Specification {
         req.packages.entries == ['https://host.com/file-lock.yml']
         and:
         req.packages.condaOpts == new CondaOpts(mambaImage: CondaOpts.DEFAULT_MAMBA_IMAGE, basePackages: CondaOpts.DEFAULT_PACKAGES)
-        req.packages.channels == ['seqera', 'conda-forge', 'bioconda', 'defaults']
+        req.packages.channels == ['conda-forge', 'bioconda', 'defaults']
         and:
         !req.packages.environment
         and:


### PR DESCRIPTION
This PR removes `seqera` from the list of Conda default channels 