### PR TITLE
Change macos-latest to macos-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-latest-xlarge, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-latest-xlarge, windows-latest]
         include:
           - os: ubuntu-latest
             fatjar: true
             musl: true
-          - os: macos-latest
+          - os: macos-12
             codesign: true
           - os: macos-latest-xlarge
             codesign: true

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -90,7 +90,7 @@ distributions:
         platform: windows-x86_64
         extraProperties:
           graalVMNativeImage: true
-      - path: "nativeCompile-macos-latest/wave"
+      - path: "nativeCompile-macos-12/wave"
         transform: "wave-{{projectEffectiveVersion}}-macos-x86_64"
         platform: osx-x86_64
         extraProperties:


### PR DESCRIPTION
The latest mac-os-latest Github runner running on ARM
So to keep wave binary compatible with x86_64, I have changed macos-latest to macos-12