### PR TITLE
update mac runner for intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, macos-latest-xlarge, windows-latest]
+        os: [ubuntu-latest, macos-latest-large, macos-latest-xlarge, windows-latest]
         include:
           - os: ubuntu-latest
             fatjar: true
             musl: true
-          - os: macos-12
+          - os: macos-latest-large
             codesign: true
           - os: macos-latest-xlarge
             codesign: true


### PR DESCRIPTION
This PR will update the mac runner in github ci 
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

solves:
![Screenshot 2024-10-16 at 15 30 13](https://github.com/user-attachments/assets/b13ef377-5a7e-4498-80af-0228013fb735)
