### PR TITLE
Added GHA to send dependency graph

### DIFF
--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -1,6 +1,7 @@
 name: Generate and submit dependency graph for wave-cli
 on:
-    pull_request:
+  push:
+    branches: ['master']
 
 permissions:
   contents: write

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Generate and submit dependency graph for wave-cli
       uses: gradle/actions/dependency-submission@v4
       with:
-        dependency-resolution-task: "dependencies"
+        dependency-resolution-task: ":app:dependencies"
         additional-arguments: "--configuration runtimeClasspath"
         dependency-graph: generate-and-submit

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -1,0 +1,23 @@
+name: Generate and submit dependency graph for wave-cli
+on:
+    pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: Generate and submit dependency graph for wave-cli
+      uses: gradle/actions/dependency-submission@v4
+      with:
+        dependency-resolution-task: "dependencies"
+        additional-arguments: "--configuration runtimeClasspath"
+        dependency-graph: generate-and-submit

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-java@v4
+    - uses: graalvm/setup-graalvm@v1
       with:
-        distribution: temurin
-        java-version: 17
+        java-version: 21
 
     - name: Generate and submit dependency graph for wave-cli
       uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
Added a GHA to send dependency graph to GIthub to get dependabot alerts.

Action has been tested:

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/4b7b53f5-9319-4bae-b771-d2d2dd366f92">
