### PR TITLE
Bump wave deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.seqera:wave-api:0.13.3'
-    implementation 'io.seqera:wave-utils:0.14.1'
+    implementation 'io.seqera:wave-api:0.14.0'
+    implementation 'io.seqera:wave-utils:0.15.0'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.squareup.moshi:moshi:1.15.0'
     implementation 'com.squareup.moshi:moshi-adapters:1.14.0'


### PR DESCRIPTION
This PR bumps `wave-utils` version 0.15.0 and `wave-api` version `0.14.0` to address dependencies vulnerability issues 