### PR TITLE
Bump wave-utils@0.15.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     implementation 'io.seqera:wave-api:0.16.0'
-    implementation 'io.seqera:wave-utils:0.15.1'
+    implementation 'io.seqera:wave-utils:0.15.2'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.squareup.moshi:moshi:1.15.2'
     implementation 'com.squareup.moshi:moshi-adapters:1.15.2'


### PR DESCRIPTION
this pr will bump-utils-0.15.2

it fixes https://github.com/seqeralabs/wave-cli/security/dependabot/9