### PR TITLE
deps: update vulnerable logback dependency

### DIFF
--- a/buildSrc/src/main/groovy/io.seqera.wave.cli.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.wave.cli.java-common-conventions.gradle
@@ -39,8 +39,8 @@ dependencies {
     implementation "org.slf4j:jcl-over-slf4j:2.0.16"
     implementation "org.slf4j:jul-to-slf4j:2.0.16"
     implementation "org.slf4j:log4j-over-slf4j:2.0.16"
-    implementation "ch.qos.logback:logback-classic:1.5.19"
-    implementation "ch.qos.logback:logback-core:1.5.19"
+    implementation "ch.qos.logback:logback-classic:1.5.20"
+    implementation "ch.qos.logback:logback-core:1.5.20"
 
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'


### PR DESCRIPTION
Update logback version to fix https://nvd.nist.gov/vuln/detail/CVE-2025-11226