### PR TITLE
Update mac runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             musl: true
           - os: macos-15-intel
             codesign: true
-          - os: macos-latest
+          - os: macos-15
             codesign: true
     steps:
       - name: Environment


### PR DESCRIPTION
This PR will update mac runners to the latest
referenced from here:
https://docs.github.com/en/actions/reference/runners/github-hosted-runners