### PR TITLE
Add --build-template option for container build templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,28 @@ If you use [Homebrew](https://brew.sh/), you can install like this:
     docker run $container sh -c hello.sh
     ```
 
-#### Build a Conda multi-packages container 
+#### Build a Conda multi-packages container
 
 ```bash
 container=$(wave --conda-package bamtools=2.5.2 --conda-package samtools=1.17)
 docker run $container sh -c 'bamtools --version && samtools --version'
 ```
+
+#### Build a Conda container using Pixi (multi-stage build)
+
+Use the `--build-template` option to select an optimized build template. The `conda/pixi:v1` template
+uses the [Pixi](https://pixi.sh/) package manager with multi-stage builds for smaller, more secure images:
+
+```bash
+container=$(wave --conda-package bamtools=2.5.2 --build-template conda/pixi:v1)
+docker run $container bamtools --version
+```
+
+Available build templates:
+- `conda/micromamba:v1` - Default Conda build using Micromamba 1.x
+- `conda/micromamba:v2` - Multi-stage build using Micromamba 2.x
+- `conda/pixi:v1` - Multi-stage build using Pixi package manager
+- `cran/installr:v1` - Build template for CRAN/R packages
 
 #### Build a container by using a Conda environment file
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.seqera:wave-api:1.28.0'
-    implementation 'io.seqera:wave-utils:1.28.0'
+    implementation 'io.seqera:wave-api:1.31.0'
+    implementation 'io.seqera:wave-utils:1.31.0'
     implementation 'info.picocli:picocli:4.6.1'
     implementation 'com.squareup.moshi:moshi:1.15.2'
     implementation 'com.squareup.moshi:moshi-adapters:1.15.2'

--- a/app/conf/reflect-config.json
+++ b/app/conf/reflect-config.json
@@ -286,6 +286,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.wave.config.PixiOpts",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.wave.config.SpackOpts",
   "allDeclaredFields":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]

--- a/app/src/main/java/io/seqera/wave/cli/App.java
+++ b/app/src/main/java/io/seqera/wave/cli/App.java
@@ -219,6 +219,9 @@ public class App implements Runnable {
     @Option(names = {"--build-compression"}, paramLabel = "<value>", description = "Specify the compression algorithm to be used for the build context, it can be 'gzip', 'zstd' or 'estargz'")
     private BuildCompression.Mode buildCompression;
 
+    @Option(names = {"--build-template"}, paramLabel = "<value>", description = "Specify the build template to be used for building the container, e.g. 'conda/pixi:v1', 'conda/micromamba:v1', 'conda/micromamba:v2', 'cran/installr:v1'")
+    private String buildTemplate;
+
     public static void main(String[] args) {
         try {
             final App app = new App();
@@ -432,6 +435,7 @@ public class App implements Runnable {
                 .withScanMode(scanMode)
                 .withScanLevels(scanLevels)
                 .withBuildCompression(compression(buildCompression))
+                .withBuildTemplate(buildTemplate)
                 ;
     }
 
@@ -735,7 +739,7 @@ public class App implements Runnable {
     }
 
     protected String serviceVersion() {
-        return serviceVersion0(getServiceVersion(), "1.28.0");
+        return serviceVersion0(getServiceVersion(), "1.31.0");
     }
 
     protected String serviceVersion0(String current, String required) {

--- a/app/src/main/resources/META-INF/build-info.properties
+++ b/app/src/main/resources/META-INF/build-info.properties
@@ -1,3 +1,3 @@
 name=wave-cli
-version=1.6.1
+version=1.7.0
 commitId=unknown

--- a/app/src/main/resources/io/seqera/wave/cli/usage-examples.txt
+++ b/app/src/main/resources/io/seqera/wave/cli/usage-examples.txt
@@ -15,6 +15,9 @@ Examples:
   # Build a container based on Conda lock file served via prefix.dev service
   wave --conda-package https://prefix.dev/envs/pditommaso/wave/conda-lock.yml
 
+  # Build a container based on Conda packages using Pixi build template
+  wave --conda-package bamtools=2.5.2 --build-template conda/pixi:v1
+
   # Build a container based on CRAN packages
   wave --cran-package dplyr=1.1.0 --cran-package ggplot2
 

--- a/app/src/test/groovy/io/seqera/wave/cli/AppTest.groovy
+++ b/app/src/test/groovy/io/seqera/wave/cli/AppTest.groovy
@@ -335,6 +335,32 @@ class AppTest extends Specification {
         req.buildCompression == new BuildCompression().withMode(BuildCompression.Mode.estargz)
     }
 
+    def 'should set build template' () {
+        given:
+        def app = new App()
+        String[] args = ["--build-template", 'conda/pixi:v1']
+
+        when:
+        new CommandLine(app).parseArgs(args)
+        and:
+        def req = app.createRequest()
+        then:
+        req.buildTemplate == 'conda/pixi:v1'
+    }
+
+    def 'should set build template micromamba' () {
+        given:
+        def app = new App()
+        String[] args = ["--build-template", 'conda/micromamba:v2']
+
+        when:
+        new CommandLine(app).parseArgs(args)
+        and:
+        def req = app.createRequest()
+        then:
+        req.buildTemplate == 'conda/micromamba:v2'
+    }
+
     def 'should not allow dry-run and await' () {
         given:
         def app = new App()

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,3 +25,4 @@ include('app')
 
 // enable for local development
 // includeBuild("../libseqera")
+// includeBuild("../wave")


### PR DESCRIPTION
## Summary
- Add `--build-template` CLI option to specify build templates for container builds
- Update wave-api and wave-utils dependencies to version 1.31.0
- Update required Wave backend version to 1.31.0
- Support build templates: `conda/micromamba:v1`, `conda/micromamba:v2`, `conda/pixi:v1`, `cran/installr:v1`

## Changes
- New `--build-template` option in `App.java` with template format `<scope>/<name>:<version>`
- Updated dependencies in `build.gradle`
- Documentation and usage examples updated in README.md and usage-examples.txt
- Added unit tests for build template option

## Test plan
- [x] Build compiles successfully with `./gradlew assemble`
- [x] All unit tests pass with `./gradlew test`
- [ ] Manual testing with Wave service

🤖 Generated with [Claude Code](https://claude.com/claude-code)