### PR TITLE
fix(deps): migrate shadow plugin to com.gradleup.shadow 8.3.9 (COMP-1547)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'groovy'
     id 'io.seqera.wave.cli.java-application-conventions'
     id 'org.graalvm.buildtools.native' version '0.10.6'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.9'
 }
 
 java {


### PR DESCRIPTION
## Summary
- The `com.github.johnrengelman.shadow` **8.1.1** Gradle build plugin transitively pulls in the vulnerable `org.codehaus.plexus:plexus-utils` **3.5.1** (Directory Traversal in `Expand.extractFile`).
- `8.1.1` is the final release under the `com.github.johnrengelman.shadow` coordinate, so it cannot be bumped in place.
- Migrates to the maintained successor `com.gradleup.shadow` **8.3.9** (same 8.x line, API-compatible with the `shadowJar` usage in this repo), which ships `plexus-utils` **4.0.2** — at or above the patched `3.6.1`.
- Resolves CVE-2025-67030 / GHSA-6fmv-xxpf-w3cw.

Verified locally: `./gradlew shadowJar` builds successfully under the project's Java 21 toolchain and produces `app/build/libs/wave.jar` as before.

## JIRA
COMP-1547: Fix Plexus-Utils has a Directory Traversal vulnerability in its extractFile method

## Security Advisory
https://github.com/seqeralabs/wave-cli/security/dependabot/15

🤖 Generated with [Claude Code](https://claude.ai/code)