### PR TITLE
fix(deps): upgrade shadow plugin to resolve log4j-core XmlLayout vuln (COMP-1573)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ matrix.musl }}
         with:
-          java-version: '21'
+          java-version: '25'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
           native-image-musl: 'true'
@@ -48,7 +48,7 @@ jobs:
       - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ !matrix.musl }}
         with:
-          java-version: '21'
+          java-version: '25'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
@@ -115,7 +115,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: test-reports-jdk-${{ matrix.java_version }}
+          name: test-reports-${{ matrix.os }}
           path: |
             **/build/reports/tests/test
   release:
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Java for JReleaser
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'adopt'
 
       - name: Version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ matrix.musl }}
         with:
           java-version: '21'
@@ -45,7 +45,7 @@ jobs:
           native-image-job-reports: 'true'
           native-image-musl: 'true'
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ !matrix.musl }}
         with:
           java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ matrix.musl }}
         with:
-          java-version: '25'
+          java-version: '21'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
           native-image-musl: 'true'
@@ -48,7 +48,7 @@ jobs:
       - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
         if: ${{ !matrix.musl }}
         with:
-          java-version: '25'
+          java-version: '21'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
 
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Java for JReleaser
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
-          java-version: '25'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Version

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
       with:
-        java-version: 25
+        java-version: 21
 
     - name: Generate and submit dependency graph for wave-cli
       uses: gradle/actions/dependency-submission@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    - uses: graalvm/setup-graalvm@v1
+    - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
       with:
         java-version: 21
 

--- a/.github/workflows/security-submit-dependecy-graph.yml
+++ b/.github/workflows/security-submit-dependecy-graph.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - uses: graalvm/setup-graalvm@cabbb10818fabc989d6dbd508e4846596d20dd2d # v1.6.0
       with:
-        java-version: 21
+        java-version: 25
 
     - name: Generate and submit dependency graph for wave-cli
       uses: gradle/actions/dependency-submission@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Wave CLI is a command-line tool for the Wave container provisioning service. It 
 - Mirror containers between registries
 - Scan containers for security vulnerabilities
 
-The CLI is built using Java 17 (with Java 21 toolchain) and compiles to a native binary using GraalVM.
+The CLI is built using Java 17 (with Java 25 toolchain) and compiles to a native binary using GraalVM.
 
 ## Architecture
 
@@ -81,7 +81,7 @@ The project compiles to a native binary with specific configuration:
 
 ### Native Compilation
 ```bash
-# Build native binary (requires GraalVM Java 21)
+# Build native binary (requires GraalVM Java 25)
 ./gradlew app:nativeCompile
 
 # Run the native binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Wave CLI is a command-line tool for the Wave container provisioning service. It 
 - Mirror containers between registries
 - Scan containers for security vulnerabilities
 
-The CLI is built using Java 17 (with Java 25 toolchain) and compiles to a native binary using GraalVM.
+The CLI is built using Java 17 (with Java 21 toolchain) and compiles to a native binary using GraalVM.
 
 ## Architecture
 
@@ -81,7 +81,7 @@ The project compiles to a native binary with specific configuration:
 
 ### Native Compilation
 ```bash
-# Build native binary (requires GraalVM Java 25)
+# Build native binary (requires GraalVM Java 21)
 ./gradlew app:nativeCompile
 
 # Run the native binary

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'groovy'
     id 'io.seqera.wave.cli.java-application-conventions'
-    id 'org.graalvm.buildtools.native' version '1.1.3'
+    id 'org.graalvm.buildtools.native' version '0.11.5'
     id 'com.gradleup.shadow' version '9.5.0'
 }
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(25)
+        languageVersion = JavaLanguageVersion.of(21)
     }
     sourceCompatibility = 17
     targetCompatibility = 17
@@ -32,10 +32,10 @@ dependencies {
     // bump commons-io version to address security vulnerabilities
     runtimeOnly 'commons-io:commons-io:2.18.0'
 
-    testImplementation "org.apache.groovy:groovy:4.0.32"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.32"
-    testImplementation "org.apache.groovy:groovy-test:4.0.32"
-    testImplementation "org.apache.groovy:groovy-json:4.0.32"
+    testImplementation "org.apache.groovy:groovy:4.0.24"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.24"
+    testImplementation "org.apache.groovy:groovy-test:4.0.24"
+    testImplementation "org.apache.groovy:groovy-json:4.0.24"
     testImplementation "net.bytebuddy:byte-buddy:1.14.11"
     testImplementation ("org.spockframework:spock-core:2.4-groovy-4.0") { exclude group: 'org.apache.groovy' }
 }
@@ -96,7 +96,7 @@ graalvmNative {
             }
 
             javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(25)
+                languageVersion = JavaLanguageVersion.of(21)
                 vendor = JvmVendorSpec.matching("Oracle Corporation")
             }
             buildArgs.add('--enable-url-protocols=https')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'groovy'
     id 'io.seqera.wave.cli.java-application-conventions'
-    id 'org.graalvm.buildtools.native' version '0.10.6'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'org.graalvm.buildtools.native' version '1.1.3'
+    id 'com.gradleup.shadow' version '9.5.0'
 }
 
 java {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
     sourceCompatibility = 17
     targetCompatibility = 17
@@ -32,10 +32,10 @@ dependencies {
     // bump commons-io version to address security vulnerabilities
     runtimeOnly 'commons-io:commons-io:2.18.0'
 
-    testImplementation "org.apache.groovy:groovy:4.0.24"
-    testImplementation "org.apache.groovy:groovy-nio:4.0.24"
-    testImplementation "org.apache.groovy:groovy-test:4.0.24"
-    testImplementation "org.apache.groovy:groovy-json:4.0.24"
+    testImplementation "org.apache.groovy:groovy:4.0.32"
+    testImplementation "org.apache.groovy:groovy-nio:4.0.32"
+    testImplementation "org.apache.groovy:groovy-test:4.0.32"
+    testImplementation "org.apache.groovy:groovy-json:4.0.32"
     testImplementation "net.bytebuddy:byte-buddy:1.14.11"
     testImplementation ("org.spockframework:spock-core:2.4-groovy-4.0") { exclude group: 'org.apache.groovy' }
 }
@@ -96,7 +96,7 @@ graalvmNative {
             }
 
             javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(21)
+                languageVersion = JavaLanguageVersion.of(25)
                 vendor = JvmVendorSpec.matching("Oracle Corporation")
             }
             buildArgs.add('--enable-url-protocols=https')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,7 +17,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
`org.apache.logging.log4j:log4j-core` is pulled in transitively by the `com.github.johnrengelman.shadow` 8.1.1 Gradle build plugin (build-tooling classpath only — it is **not** on the application runtime classpath). Shadow 8.1.1 bundles log4j-core `2.20.0`, affected by **CVE-2026-34480 / GHSA-3pxv-7cmr-fjr4** (Apache Log4j Core's `XmlLayout` fails to sanitize XML-1.0-forbidden characters; **fixed in log4j-core `2.25.4`**).

Per policy we do not force-pin transitive dependencies — we upgrade the declaring build plugin. Only the shadow `9.x` line bundles log4j-core ≥ `2.25.4` (the `8.3.x` line tops out at `2.25.3`), and shadow `9.x` requires Gradle 9:

- `com.github.johnrengelman.shadow` `8.1.1` → `com.gradleup.shadow` `9.5.0` (successor lineage; ships log4j-core `2.26.1` ≥ `2.25.4`)
- Gradle wrapper `8.13` → `9.6.1` (required by shadow 9.x)
- `org.graalvm.buildtools.native` `0.10.6` → `0.11.5` (the 0.11.x line adds Gradle 9 support while keeping the legacy GraalVM reachability-metadata schema)

**The build toolchain is unchanged from master: GraalVM/JDK 21, Groovy 4.0.24, `source/targetCompatibility` 17.** The shipped fat jar still runs on JRE 17+.

## Note on native-build-tools version choice
An earlier iteration used native-build-tools `1.1.3`, which broke `nativeCompile`: the `1.x` line downloads the latest GraalVM reachability-metadata repository, whose new unified `reachability-metadata.json` schema is **not accepted by GraalVM for JDK 21 or 25.0.1** (verified in CI — bumping the JDK did not help). `0.11.5` supports Gradle 9 but keeps the legacy metadata schema, so the metadata repository stays enabled and the schema mismatch disappears without any JDK/Groovy changes.

## Also included
- Pinned the pre-existing `graalvm/setup-graalvm@v1` refs to a full commit SHA (`cabbb10818fabc989d6dbd508e4846596d20dd2d`, v1.6.0), now required by org policy.
- Fixed a pre-existing broken test-report artifact name that referenced the undefined `matrix.java_version` (collided across all OS jobs) → now `matrix.os`, matching the `nativeCompile` artifact naming.

## Verification
- `./gradlew clean test shadowJar` passes under Gradle 9.6.1 on the JDK 21 toolchain
- The produced `wave.jar` runs (`--version`)
- Native compile (`nativeCompile`) requires GraalVM and is verified by CI on this PR

## JIRA
COMP-1573: Fix Apache Log4j Core's XmlLayout fails to sanitize characters

## Security Advisory
https://github.com/seqeralabs/wave-cli/security/dependabot/16

🤖 Generated with [Claude Code](https://claude.ai/code)